### PR TITLE
Let TSLint resolve plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,10 @@
 'use strict';
-const path = require('path');
-
-// TODO: TSLint should improve this:
-// https://github.com/palantir/tslint/issues/3436
-const getRuleDirectory = (name, directory) =>
-	path.join(path.dirname(require.resolve(name)), directory || '');
 
 module.exports = {
 	rulesDirectory: [
-		getRuleDirectory('tslint-eslint-rules', 'dist/rules'),
-		getRuleDirectory('tslint-consistent-codestyle'),
-		getRuleDirectory('tslint-microsoft-contrib')
+		'tslint-eslint-rules/dist/rules',
+		'tslint-consistent-codestyle',
+		'tslint-microsoft-contrib/dist/src'
 	],
 	rules: {
 		'adjacent-overload-signatures': true,


### PR DESCRIPTION
Per https://github.com/palantir/tslint/issues/3436#issuecomment-341232546

But it doesn't seem to work. I'm getting this error:

> Could not find custom rule directory: tslint-eslint-rules/dist/rules

And it didn't work when I used this branch of `tslint-xo` in my projects either.