### PR TITLE
Allow named function declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
 		'no-reference': true,
 		'no-unnecessary-type-assertion': true,
 		'no-var-requires': true,
-		'only-arrow-functions': true,
+		'only-arrow-functions': [true, "allow-named-functions"],
 		'prefer-for-of': true,
 		'promise-function-async': true,
 		'await-promise': true,

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
 		'no-reference': true,
 		'no-unnecessary-type-assertion': true,
 		'no-var-requires': true,
-		'only-arrow-functions': [true, "allow-named-functions"],
+		'only-arrow-functions': [true, 'allow-named-functions'],
 		'prefer-for-of': true,
 		'promise-function-async': true,
 		'await-promise': true,


### PR DESCRIPTION
https://github.com/xojs/tslint-xo/blob/master/index.js#L27
https://github.com/xojs/tslint-xo/blob/master/index.js#L195

The rule `"only-arrow-functions": true` is set but it looks like you were just trying to disallow function expressions.

https://palantir.github.io/tslint/rules/only-arrow-functions/