### PR TITLE
Remove newline-before-return rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,6 @@ module.exports = {
 		'import-spacing': true,
 		'interface-over-type-literal': true,
 		'jsdoc-format': [true, 'check-multiline-start'],
-		'newline-before-return': false,
 		'new-parens': true,
 		'no-angle-bracket-type-assertion': true,
 		'no-boolean-literal-compare': false,

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = {
 		'import-spacing': true,
 		'interface-over-type-literal': true,
 		'jsdoc-format': [true, 'check-multiline-start'],
-		'newline-before-return': true,
+		'newline-before-return': false,
 		'new-parens': true,
 		'no-angle-bracket-type-assertion': true,
 		'no-boolean-literal-compare': false,


### PR DESCRIPTION
This rule is not in the main XO config and is just awkward sometimes.