### PR TITLE
Falsify newline-before-return rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ module.exports = {
 		'import-spacing': true,
 		'interface-over-type-literal': true,
 		'jsdoc-format': [true, 'check-multiline-start'],
+		'newline-before-return': false,
 		'new-parens': true,
 		'no-angle-bracket-type-assertion': true,
 		'no-boolean-literal-compare': false,


### PR DESCRIPTION
Sorry for opening this again. This rule must be included as false, as it is being set by a config that you're extending from.